### PR TITLE
Mana barrel fixes

### DIFF
--- a/ZSCRIPT.ManaBarrel.zsc
+++ b/ZSCRIPT.ManaBarrel.zsc
@@ -62,10 +62,7 @@ class ManaBarrel : Actor
 		}
 		//if (!(user.player.ReadyWeapon is 'HDHealingBottler' ||self.countinv('HDHealingPotion') >> 0))
 		let potion = HDWeapon(user.FindInventory('HDHealingPotion'));
-		if (!potion)
-		{
-			return false;
-		}
+
 		if (!(user.player.ReadyWeapon is 'HDHealingPotion'))
 		{
 			double maxSipFac = HDPlayerPawn(user) && HDPlayerPawn(user).incapacitated > 0 ? 0.9 : 0.8;
@@ -83,6 +80,10 @@ class ManaBarrel : Actor
 			return false;
 		}
 
+		if (!potion)
+		{
+			return false;
+		}
 
 
 		else if (potion.weaponstatus[HDHM_AMOUNT] < HDHM_BOTTLE)

--- a/ZSCRIPT.ManaBarrel.zsc
+++ b/ZSCRIPT.ManaBarrel.zsc
@@ -61,9 +61,12 @@ class ManaBarrel : Actor
 			return false;
 		}
 		//if (!(user.player.ReadyWeapon is 'HDHealingBottler' ||self.countinv('HDHealingPotion') >> 0))
-		let potion = HDMagAmmo(user.FindInventory('HDHealingPotion'));
-		int lowestIndex = AceCore.GetLowestMag(potion, 0);
-		if (!(user.player.ReadyWeapon is 'HDHealingBottler' ||self.countinv('HDHealingPotion') >= 1 || potion.Mags[lowestIndex] < HDHM_BOTTLE))
+		let potion = HDWeapon(user.FindInventory('HDHealingPotion'));
+		if (!potion)
+		{
+			return false;
+		}
+		if (!(user.player.ReadyWeapon is 'HDHealingPotion'))
 		{
 			double maxSipFac = HDPlayerPawn(user) && HDPlayerPawn(user).incapacitated > 0 ? 0.9 : 0.8;
 			if (ManaLeft >= TotalMana * maxSipFac)
@@ -80,28 +83,19 @@ class ManaBarrel : Actor
 			return false;
 		}
 
-		//let potion = HDMagAmmo(user.FindInventory('HDHealingPotion'));
-		if (!potion)
-		{
-			return false;
-		}
 
-		//int lowestIndex = AceCore.GetLowestMag(potion, 0);
-		//if (lowestIndex > -1)
-		if (lowestIndex > -1)
+
+		else if (potion.weaponstatus[HDHM_AMOUNT] < HDHM_BOTTLE)
 		{
-			if (potion.Mags[lowestIndex] < HDHM_BOTTLE)
-			{
-				int toFill = min(ManaLeft, HDHM_BOTTLE - potion.Mags[lowestIndex]);
+				int toFill = min(ManaLeft, HDHM_BOTTLE - potion.weaponstatus[HDHM_AMOUNT]);
 				
-				potion.Mags[lowestIndex] += toFill;
+				potion.weaponstatus[HDHM_AMOUNT] += toFill;
 				ManaLeft -= toFill;
 
 				double potsLeft = ManaLeft / double(HDHM_BOTTLE);
 				string extra = potsLeft > 0 ? String.Format(" There is still enough mana to fill \c[LightBlue]%.1f\c- bottles.", potsLeft) : " That was the last of the mana.";
 				user.A_Log("You filled a potion."..extra, true);
 				user.A_StartSound("potion/swish", 15);
-			}
 		}
 
 		return false;


### PR DESCRIPTION
Resolves #4, #5, and #6
I'm not familiar with how the barrel worked before it broke, but it looked like it would fill the lowest potion in inventory. Can't get that now that they're HDWeapons, so it just fills the one you have in your hands when you use the barrel.