### PR TITLE
Localize all of the Arcanum

### DIFF
--- a/LANGUAGE
+++ b/LANGUAGE
@@ -36,6 +36,30 @@ MANABARREL_POTFILL = "You filled a potion.";
 ARCANUM_TREE_DESTRUCTION = "\c[Red]Destruction\c-";
 ARCANUM_TREE_DESTRUCTION_DESC = "Those who wish to destroy the world may find out how trivial it is. But is it really what you want?\n\nThis tree contains spells to call down thunder, annihilate entire hordes, or light a candle.";
 
+DESTRUCTION_CLAYMORE_NAME = "Claymore";
+DESTRUCTION_CLAYMORE_DESC = "Activate the rune to create a trap that will activate when an enemy is in front of it.";
+DESTRUCTION_CLAYMORE_INFO = "Touch, Physical";
+
+DESTRUCTION_FIREBALL_NAME = "Fireball";
+DESTRUCTION_FIREBALL_DESC = "Barrage the targeted area with \c[Gold]%i\c- fireballs.";
+DESTRUCTION_FIREBALL_INFO = "Targeted, Thermal, Dangerous";
+
+DESTRUCTION_HAMMERFIST_NAME = "Hammerfist";
+DESTRUCTION_HAMMERFIST_DESC = "A giant fist drops down from the sky and crushes a single target.";
+DESTRUCTION_HAMMERFIST_INFO = "Targeted, Physical";
+
+DESTRUCTION_IMMOLATION_NAME = "Immolation";
+DESTRUCTION_IMMOLATION_DESC = "Sets all enemies within \c[Gold]%.1f\c-m on fire.";
+DESTRUCTION_IMMOLATION_INFO = "Mass, Thermal";
+
+DESTRUCTION_THUNDERCLAP_NAME = "Thunderclap";
+DESTRUCTION_THUNDERCLAP_DESC = "Strikes target area with \c[Gold]%i\c- lightning bolt%s.";
+DESTRUCTION_THUNDERCLAP_INFO = "Targeted, AoE, Electrical, Dangerous";
+
+DESTRUCTION_VOIDSTORM_NAME = "Voidstorm";
+DESTRUCTION_VOIDSTORM_DESC = "Launches forward a black hole that sucks enemies in and removes them from existence. It explodes once it comes into contact with a hard surface.";
+DESTRUCTION_VOIDSTORM_INFO = "Mass, Dangerous";
+
 // RESTORATION
 ARCANUM_TREE_RESTORATION = "\c[Tan]Restoration\c-";
 ARCANUM_TREE_RESTORATION_DESC = "It is a wise man's goal to heal the world.\n\nRestoration spells give you the ability to resurrect friends or foes, heal their wounds, cleanse their body, and protect it.";

--- a/LANGUAGE
+++ b/LANGUAGE
@@ -1,0 +1,85 @@
+[enu default]
+
+// The Book:tm:
+ARCANUM_PLACERUNE = "  Place rune\n";
+ARCANUM_SPELLCIRCLE = "  Create spell circle\n";
+ARCANUM_SPELLMANAGER = "  Spell manager";
+ARCANUM_CYCLESPELLS = "  Cycle spells\n";
+ARCANUM_CYCLESPELLTREES = "  Cycle spell trees\n";
+ARCANUM_EXITMANAGER = "  Exit spell manager";
+ARCANUM_PLUS = "+";
+ARCANUM_OR = " or ";
+ARCANUM_SPELLS = "Spells";
+ARCANUM_EXPERIENCE = "Experience";
+ARCANUM_COSTCOLOR = "\c[ArcanumReqBlue]%i\c-";
+ARCANUM_COST = "\c[DarkGray]Cost: ";
+ARCANUM_FULLPOWERCOLOR = "\c[Fire]";
+ARCANUM_REACHEDFULLPOWER = "\c- has reached full power.";
+ARCANUM_YOURKNOWLEDGE = "Your knowledge of \c[Fire]";
+ARCANUM_INCREASES = "\c- increases.";
+ARCANUM_FAILLEARN = "You fail to learn anything new.";
+ARCANUM_NOTPOWERFUL = "You don't feel powerful enough to cast ";
+ARCANUM_PERIOD = ".";
+
+ARCANUM_TAG = "Arcanum tome";
+ARCANUM_PICKUP = "You picked up the Arcanum tome of knowledge. Unlimited power awaits those with the energy within.";
+
+// Mana Barrel
+MANABARREL_EMPTY = "This barrel is empty.";
+MANABARREL_SIP = "You take a sip.";
+MANABARREL_CANTREACH = "You can't reach anything.";
+MANABARREL_MANACOUNT = " There is still enough mana to fill \c[LightBlue]%.1f\c- bottles.";
+MANABARREL_NOMOREMANA = " That was the last of the mana.";
+MANABARREL_POTFILL = "You filled a potion.";
+
+// DESTRUCTION
+ARCANUM_TREE_DESTRUCTION = "\c[Red]Destruction\c-";
+ARCANUM_TREE_DESTRUCTION_DESC = "Those who wish to destroy the world may find out how trivial it is. But is it really what you want?\n\nThis tree contains spells to call down thunder, annihilate entire hordes, or light a candle.";
+
+// RESTORATION
+ARCANUM_TREE_RESTORATION = "\c[Tan]Restoration\c-";
+ARCANUM_TREE_RESTORATION_DESC = "It is a wise man's goal to heal the world.\n\nRestoration spells give you the ability to resurrect friends or foes, heal their wounds, cleanse their body, and protect it.";
+
+// ALTERATION
+ARCANUM_TREE_ALTERATION = "\c[Green]Alteration\c-";
+ARCANUM_TREE_ALTERATION_DESC = "Nothing is as it appears. Manipulate the world to your liking.\n\nThe school of Alteration lets you destroy entire walls or otherwise manipulate objects.";
+
+ALTERATION_DISPLACEMENT_NAME = "Displacement";
+ALTERATION_DISPLACEMENT_DESC = "Partly severs your link to this world and gives you the ability to fly for 4 seconds, then teleports you to where you cast the spell. Enemies cannot see you while being displaced.";
+ALTERATION_DISPLACEMENT_INFO = "Self";
+
+ALTERATION_FARREACH_NAME = "Far Reach";
+ALTERATION_FARREACH_DESCRIPTION = "Open doors, trigger switches, and pick up items within a range of \c[Gold]%.1f\c-m.\nDisarms ammo boxes.\n\n\c[Fire]You can launch yourself forward with this spell. Use with caution.\c-";
+ALTERATION_FARREACH_INFO = "Targeted";
+
+ALTERATION_FEATHER_NAME = "Feather";
+ALTERATION_FEATHER_DESC = "Creates a circle at target location. Players falling into the circle get their vertical velocity reduced to a safe level. Gravity is also reduced.";
+ALTERATION_FEATHER_INFO = "Targeted";
+
+ALTERATION_HASTE_NAME = "Haste";
+ALTERATION_HASTE_DESC = "All visible players within 20m get an increase to speed by \c[Gold]%i\c-%%. Effect expires after \c[Gold]%.1f\c- km.";
+ALTERATION_HASTE_INFO = "Mass";
+
+ALTERATION_HORADRICMALUS_NAME = "Horadric Malus";
+ALTERATION_HORADRICMALUS_DESC = "Repairs repairable items by \c[Gold]%i%%\c- of their missing durability. Repairs Vulcanettes and *.E.R.P.s, among other things.";
+ALTERATION_HORADRICMALUS_INFO = "Self, Targeted, Touch";
+
+ALTERATION_MASSRECALL_NAME = "Mass Recall";
+ALTERATION_MASSRECALL_DESC = "Teleports all players, dead or alive, to the circle.";
+ALTERATION_MASSRECALL_INFO = "Mass";
+
+ALTERATION_REENERGIZE_NAME = "Reenergize";
+ALTERATION_REENERGIZE_DESC = "Restores up to \c[Gold]%i\c- battery charge, filling partial batteries first.";
+ALTERATION_REENERGIZE_INFO = "Self, Targeted, Touch";
+
+ALTERATION_SHIELD_NAME = "Shield";
+ALTERATION_SHIELD_DESC = "Target is surrounded with a shield that can absorb up to \c[Gold]%i\c- damage. Shield helps put out fire.";
+ALTERATION_SHIELD_INFO = "Self, Targeted, Touch";
+
+ALTERATION_WORLDBREAKER_NAME = "Worldbreaker";
+ALTERATION_WORLDBREAKER_DESC = "Destroys the target geometry. Maximum sector dimensions: \c[Gold]%ix%i\c-\n\n\c[Fire]Effect occurs 3 seconds after activation.\c-";
+ALTERATION_WORLDBREAKER_INFO = "Targeted, Touch";
+
+// CONJURATION
+ARCANUM_TREE_CONJURATION = "\c[Purple]Conjuration\c-";
+ARCANUM_TREE_CONJURATION_DESC = "If it does not exist, make it.\n\nConjuration is for the strongest of magi. With it, you can summon monsters or materialize objects.";

--- a/LANGUAGE
+++ b/LANGUAGE
@@ -64,6 +64,35 @@ DESTRUCTION_VOIDSTORM_INFO = "Mass, Dangerous";
 ARCANUM_TREE_RESTORATION = "\c[Tan]Restoration\c-";
 ARCANUM_TREE_RESTORATION_DESC = "It is a wise man's goal to heal the world.\n\nRestoration spells give you the ability to resurrect friends or foes, heal their wounds, cleanse their body, and protect it.";
 
+RESTORATION_INVULNERABILITY_NAME = "Invulnerability";
+RESTORATION_INVULNERABILITY_DESC = "Grants temporary invulnerability that lasts 90 seconds.\n\n\c[Fire]Warning: will set everything on fire.\c-";
+RESTORATION_INVULNERABILITY_INFO = "Self, Targeted, Touch";
+
+RESTORATION_LIFEFORCE_NAME = "Life Force";
+RESTORATION_LIFEFORCE_DESC = "Fixes all wounds and restores \c[Gold]%i\c-%% of missing health. Heals \c[Gold]%i\c- burns. Reduces aggro by \c[Gold]%i\c-. Restores lost blood and removes incap.";
+RESTORATION_LIFEFORCE_INFO = "Self, Targeted, Touch";
+
+RESTORATION_RAGE_NAME = "Rage";
+RESTORATION_RAGE_DESC = "[this page is full of incomprehensible scribbles]";
+RESTORATION_RAGE_INFO = "Self, Targeted, Touch";
+
+RESTORATION_RESURRECT_NAME = "Resurrect";
+RESTORATION_RESURRECT_DESC = "Resurrects up to \c[Gold]%i\c- targets within \c[Gold]%.1f\c-m of where the sigil was cast.";
+RESTORATION_RESURRECT_INFO = "Mass";
+
+RESTORATION_REVITALIZATION_NAME = "Revitalization";
+RESTORATION_REVITALIZATION_DESC = "Recover \c[Gold]%i\c- health every heartbeat. Effect expires after \c[Gold]%i\c- health points. Prevents pain jolts from second flesh for the duration of the effect. Helps with zerk comedown.";
+RESTORATION_REVITALIZATION_INFO = "Self, Targeted, Touch";
+
+RESTORATION_SOULGUARD_NAME = "Shield Guard";
+RESTORATION_SOULGUARD_DESC = "Grants \c[Gold]%i\c- shield core%s.";
+RESTORATION_SOULGUARD_DESC2 = "s";
+RESTORATION_SOULGUARD_INFO = "Self, Targeted";
+
+RESTORATION_TRANSFUSION_NAME = "Transfusion";
+RESTORATION_TRANSFUSION_DESC = "Transfers all of the tome's stored blues to the target.";
+RESTORATION_TRANSFUSION_INFO = "Targeted, Touch";
+
 // ALTERATION
 ARCANUM_TREE_ALTERATION = "\c[Green]Alteration\c-";
 ARCANUM_TREE_ALTERATION_DESC = "Nothing is as it appears. Manipulate the world to your liking.\n\nThe school of Alteration lets you destroy entire walls or otherwise manipulate objects.";

--- a/LANGUAGE
+++ b/LANGUAGE
@@ -83,3 +83,33 @@ ALTERATION_WORLDBREAKER_INFO = "Targeted, Touch";
 // CONJURATION
 ARCANUM_TREE_CONJURATION = "\c[Purple]Conjuration\c-";
 ARCANUM_TREE_CONJURATION_DESC = "If it does not exist, make it.\n\nConjuration is for the strongest of magi. With it, you can summon monsters or materialize objects.";
+
+CONJURATION_BARRIER_NAME = "Barrier";
+CONJURATION_BARRIER_DESC = "Creates a 10m-wide impenetrable energy wall 1m in front of you. Lasts 90 seconds. Blocks movement and projectiles.";
+CONJURATION_BARRIER_INFO = "Touch";
+
+CONJURATION_BRIDGE_NAME = "Bridge";
+CONJURATION_BRIDGE_DESC = "Creates a 20m-long energy bridge. Lasts 30 seconds.";
+CONJURATION_BRIDGE_INFO = "Angled";
+
+CONJURATION_CANDLELIGHT_NAME = "Candlelight";
+CONJURATION_CANDLELIGHT_DESC = "Emit a bright light with a radius of \c[Gold]%.1f\c-m for \c[Gold]%.1f\c- minutes.";
+CONJURATION_CANDLELIGHT_INFO = "Self";
+
+CONJURATION_GHOSTSQUAD_NAME = "Ghost Squad";
+CONJURATION_GHOSTSQUAD_DESC = "Summons \c[Gold]%i\c- ghost marine%s at target location.";
+CONJURATION_GHOSTSQUAD_DESC2 = "s";
+CONJURATION_GHOSTSQUAD_INFO = "Targeted";
+CONJURATION_GHOSTSQUAD_ACTIVATE1 = "\cj'They shall stand again and hear there\n\cja horn in the hills ringing.\n\n\cjWhose shall the horn be?'";
+CONJURATION_GHOSTSQUAD_ACTIVATE2 = "\cj'For this war will last through years uncounted\n\n\cjand you shall be summoned once again ere the end.'";
+CONJURATION_GHOSTSQUAD_ACTIVATE3 = "\cj'Faint cries I heard,and dim horns blowing,\n\n\cjand a murmur as of countless far voices:\n\n\n\cjit was like the echo of some forgotten battle\n\n\cjin the Dark Years long ago.'";
+CONJURATION_GHOSTSQUAD_ACTIVATE4 = "\cj'Pale swords were drawn; but I know not\n\n\cjwhether their blades would still bite,\n\n\n\cjfor the Dead needed no longer\n\n\cjany weapon but fear.'";
+
+CONJURATION_GUARDIANORB_NAME = "Guardian Orb";
+CONJURATION_GUARDIANORB_DESC = "A point defense orb that orbits its target, shooting down inbound tracers and small floating monsters within 5m. Can summon up to \c[Gold]%i\c- orb%s.";
+CONJURATION_GUARDIANORB_DESC2 = "s";
+CONJURATION_GUARDIANORB_INFO = "Self, Targeted, Touch";
+
+CONJURATION_HOLYFORCE_NAME = "Holy Force";
+CONJURATION_HOLYFORCE_DESC = "Prevents all archviles within 20m from disappearing until they die. Forces it out of hiding if it's invisible. If no archviles were affected, trigger nearby curses, if any. Reveals possessed barrels.";
+CONJURATION_HOLYFORCE_INFO = "Mass";

--- a/zscript/accensus/arcanum/ArcanumSpell.zsc
+++ b/zscript/accensus/arcanum/ArcanumSpell.zsc
@@ -42,26 +42,26 @@ class ArcanumSpellTree abstract play
 
 class ArcanumTreeDestruction : ArcanumSpellTree
 {
-	override string GetName() { return "\c[Red]Destruction\c-"; }
-	override string GetDescription() { return "Those who wish to destroy the world may find out how trivial it is. But is it really what you want?\n\nThis tree contains spells to call down thunder, annihilate entire hordes, or light a candle."; }
+	override string GetName() { return Stringtable.Localize("$ARCANUM_TREE_DESTRUCTION"); }
+	override string GetDescription() { return Stringtable.Localize("$ARCANUM_TREE_DESTRUCTION_DESC"); }
 }
 
 class ArcanumTreeRestoration : ArcanumSpellTree
 {
-	override string GetName() { return "\c[Tan]Restoration\c-"; }
-	override string GetDescription() { return "It is a wise man's goal to heal the world.\n\nRestoration spells give you the ability to resurrect friends or foes, heal their wounds, cleanse their body, and protect it."; }
+	override string GetName() { return Stringtable.Localize("$ARCANUM_TREE_RESTORATION"); }
+	override string GetDescription() { return Stringtable.Localize("$ARCANUM_TREE_RESTORATION_DESC"); }
 }
 
 class ArcanumTreeAlteration : ArcanumSpellTree
 {
-	override string GetName() { return "\c[Green]Alteration\c-"; }
-	override string GetDescription() { return "Nothing is as it appears. Manipulate the world to your liking.\n\nThe school of Alteration lets you destroy entire walls or otherwise manipulate objects."; }
+	override string GetName() { return Stringtable.Localize("$ARCANUM_TREE_ALTERATION"); }
+	override string GetDescription() { return Stringtable.Localize("$ARCANUM_TREE_ALTERATION_DESC"); }
 }
 
 class ArcanumTreeConjuration : ArcanumSpellTree
 {
-	override string GetName() { return "\c[Purple]Conjuration\c-"; }
-	override string GetDescription() { return "If it does not exist, make it.\n\nConjuration is for the strongest of magi. With it, you can summon monsters or materialize objects."; }
+	override string GetName() { return Stringtable.Localize("$ARCANUM_TREE_CONJURATION"); }
+	override string GetDescription() { return Stringtable.Localize("$ARCANUM_TREE_CONJURATION_DESC"); }
 }
 
 class ArcanumSpell abstract play
@@ -82,6 +82,15 @@ class ArcanumSpell abstract play
 	abstract int GetMaxExperience() const;
 	abstract class<ArcanumSigil> GetSigil() const;	
 	virtual ui void DrawHudStuff(HDStatusBar sb, HDPlayerPawn hpl, HDArcanumTome tome) { }
+	
+	// Made to make localization much easier. Taken from Lithium. - [tedthepraimortis]
+	static clearScope string loc(string nm) { 
+		if(nm.charat(0)=="$"){
+			nm = nm.mid(1);
+		}
+		string rtrn=StringTable.localize(nm, false);
+		return rtrn!=nm?rtrn:""..rtrn.." doesn't exist! try inputting it into the language lump or checking your spelling!";
+	}
 
 	// [Ace; 17.01.22] This is currently unused because I've opted for a threshold system rather than a time duration.
 	// HDest is a slow mod so half the time the effects expire before you've made use of them or they require you to know in advance that you'd need them.

--- a/zscript/accensus/arcanum/ArcanumTome.zsc
+++ b/zscript/accensus/arcanum/ArcanumTome.zsc
@@ -68,6 +68,14 @@ class HDArcanumTome : HDWeapon
 			AccumulatedBlues = 0;
 		}
 	}
+			
+	static clearScope string loc(string nm) { 
+	if(nm.charat(0)=="$"){
+		nm = nm.mid(1);
+	}
+		string rtrn=StringTable.localize(nm, false);
+		return rtrn!=nm?rtrn:""..rtrn.." doesn't exist! try inputting it into the language lump or checking your spelling!";
+	}
 
 	override void PreTravelled()
 	{
@@ -88,15 +96,15 @@ class HDArcanumTome : HDWeapon
 	override string, double GetPickupSprite() { return "ARCTZ0", 1.0; }
 	override string GetHelpText()
 	{
-		string HText = WEPHELP_FIRE.."  Place rune\n"
-		..WEPHELP_ALTFIRE.."  Create spell circle\n"
-		..WEPHELP_ZOOM.."  Spell manager";
+		string HText = LWPHELP_FIRE..loc("$ARCANUM_PLACERUNE")
+		..LWPHELP_ALTFIRE..loc("$ARCANUM_SPELLCIRCLE")
+		..LWPHELP_ZOOM..loc("$ARCANUM_SPELLMANAGER");
 
 		if (WeaponStatus[ATProp_Flags] & ATF_InSpellMenu)
 		{
-			HText = WEPHELP_FIRE.." or "..WEPHELP_ALTFIRE.."  Cycle spells\n"
-			..WEPHELP_FIREMODE.."+"..WEPHELP_FIRE.." or "..WEPHELP_ALTFIRE.."  Cycle spell trees\n"
-			..WEPHELP_ZOOM.."  Exit spell manager";
+			HText = LWPHELP_FIRE..loc("ARCANUM_OR")..LWPHELP_ALTFIRE..loc("$ARCANUM_CYCLESPELLS")
+			..LWPHELP_FIREMODE..loc("ARCANUM_PLUS")..LWPHELP_FIRE..loc("ARCANUM_OR")..LWPHELP_ALTFIRE..loc("$ARCANUM_CYCLESPELLTREES")
+			..LWPHELP_ZOOM..loc("$ARCANUM_EXITMANAGER");
 		}
 
 		return HText;
@@ -179,7 +187,7 @@ class HDArcanumTome : HDWeapon
 		sb.DrawString(TitleFont, SelTree.GetName(), (-140, baseOffset), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT);
 		sb.DrawString(DescFont, SelTree.GetDescription(), (-140, baseOffset + 20), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_WHITE, 1.0, 280, 1);
 
-		sb.DrawString(TitleFont, "Spells", (-140, baseOffset + 90), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT);
+		sb.DrawString(TitleFont, loc("$ARCANUM_SPELLS"), (-140, baseOffset + 90), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT);
 		for (int i = 0; i < SelTree.Spells.Size(); ++i)
 		{
 			ArcanumSpell CurSpell = SelTree.Spells[i];
@@ -190,7 +198,7 @@ class HDArcanumTome : HDWeapon
 		sb.DrawString(TitleFont, selSpell.GetName(), (-40, yOff), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_TEAL);
 		if (selSpell.GetMaxExperience() > 0)
 		{
-			sb.DrawString(DescFont, "Experience", (-40, yOff + 20), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_GOLD);
+			sb.DrawString(DescFont, loc("$ARCANUM_EXPERIENCE"), (-40, yOff + 20), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_GOLD);
 			string expStr = "[";
 			for (int i = 0; i < 16; ++i)
 			{
@@ -211,8 +219,8 @@ class HDArcanumTome : HDWeapon
 		double mult = AceCore.CheckForItem(hpl, "HDSoulCube") ? 0.80 : 1.0;
 		int cost = int(selSpell.GetManaCost() * mult);
 
-		string str = String.Format("\c[ArcanumReqBlue]%i\c-", cost);
-		sb.DrawString(DescFont, "\c[DarkGray]Cost: "..str, (-40, yOff + 30), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT);
+		string str = String.Format(loc("$ARCANUM_COSTCOLOR"), cost);
+		sb.DrawString(DescFont, loc("$ARCANUM_COST")..str, (-40, yOff + 30), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT);
 		sb.DrawString(DescFont, selSpell.GetDescription(), (-40, yOff + 50), sb.DI_SCREEN_CENTER | sb.DI_TEXT_ALIGN_LEFT, Font.CR_WHITE, 1.0, 180, 1);
 	}
 
@@ -338,16 +346,16 @@ class HDArcanumTome : HDWeapon
 				ArcanumSpell randSpell = valid[random(0, valid.Size() - 1)];
 				if (randSpell.GainExperience(randSpell.GetMaxExperience() / (multiplayer ? 4.0 : 5.0)))
 				{
-					other.A_Log("\c[Fire]"..randSpell.GetName().."\c- has reached full power.", true);
+					other.A_Log(loc("$ARCANUM_FULLPOWERCOLOR")..randSpell.GetName()..loc("$ARCANUM_REACHEDFULLPOWER"), true);
 				}
 				else
 				{
-					other.A_Log("Your knowledge of \c[Fire]"..randSpell.GetName().."\c- increases.", true);
+					other.A_Log(loc("$ARCANUM_YOURKNOWLEDGE")..randSpell.GetName()..loc("$ARCANUM_INCREASES"), true);
 				}
 			}
 			else
 			{
-				other.A_Log("You fail to learn anything new.", true);
+				other.A_Log(loc("$ARCANUM_FAILLEARN"), true);
 			}
 			
 			other.A_StartSound("weapons/pocket");
@@ -373,11 +381,11 @@ class HDArcanumTome : HDWeapon
 		+INVENTORY.INVBAR
 		HDWeapon.BarrelSize 5, 2, 1; // [Ace] I don't even know why.
 		Scale 0.6;
-		Tag "Arcanum tome";
+		Tag "$ARCANUM_TAG";
 		Inventory.PickupSound "weapons/pocket";
 		HDWeapon.Refid "arc";
 		Inventory.MaxAmount 1;
-		Inventory.PickupMessage "You picked up the Arcanum tome of knowledge. Unlimited power awaits those with the energy within.";
+		Inventory.PickupMessage "$ARCANUM_PICKUP";
 	}
 
 	States
@@ -610,7 +618,7 @@ class HDArcanumTome : HDWeapon
 				}
 				else
 				{
-					A_WeaponMessage("You don't feel powerful enough to cast "..selSpell.GetName()..".");
+					A_WeaponMessage(loc("$ARCANUM_NOTPOWERFUL")..selSpell.GetName()..loc("$ARCANUM_PERIOD"));
 				}
 			}
 			ARCT A 2;

--- a/zscript/accensus/arcanum/ManaBarrel.zsc
+++ b/zscript/accensus/arcanum/ManaBarrel.zsc
@@ -57,7 +57,7 @@ class ManaBarrel : Actor
 
 		if (ManaLeft == 0)
 		{
-			user.A_Log("This barrel is empty.", true);
+			user.A_Log(Stringtable.Localize("$MANABARREL_EMPTY"), true);
 			return false;
 		}
 		//if (!(user.player.ReadyWeapon is 'HDHealingBottler' ||self.countinv('HDHealingPotion') >> 0))
@@ -69,13 +69,13 @@ class ManaBarrel : Actor
 			if (ManaLeft >= TotalMana * maxSipFac)
 			{
 				user.A_GiveInventory('HealingMagic', HDHM_MOUTH);
-				user.A_Log("You take a sip.", true);
+				user.A_Log(Stringtable.Localize("$MANABARREL_SIP"), true);
 				user.A_StartSound("potion/chug", 15);
 				ManaLeft--;
 			}
 			else
 			{
-				user.A_Log("You can't reach anything.", true);
+				user.A_Log(Stringtable.Localize("$MANABARREL_CANTREACH"), true);
 			}
 			return false;
 		}
@@ -94,8 +94,8 @@ class ManaBarrel : Actor
 				ManaLeft -= toFill;
 
 				double potsLeft = ManaLeft / double(HDHM_BOTTLE);
-				string extra = potsLeft > 0 ? String.Format(" There is still enough mana to fill \c[LightBlue]%.1f\c- bottles.", potsLeft) : " That was the last of the mana.";
-				user.A_Log("You filled a potion."..extra, true);
+				string extra = potsLeft > 0 ? String.Format(Stringtable.Localize("$MANABARREL_MANACOUNT"), potsLeft) : Stringtable.Localize("$MANABARREL_NOMOREMANA");
+				user.A_Log(Stringtable.Localize("$MANABARREL_POTFILL")..extra, true);
 				user.A_StartSound("potion/swish", 15);
 		}
 

--- a/zscript/accensus/arcanum/Spells/Alteration/Displacement.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/Displacement.zsc
@@ -2,11 +2,11 @@ class DisplacementSpell : ArcanumSpell
 {
 	override int GetIndex() { return 70; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Displacement"; }
+	override string GetName() { return loc("$ALTERATION_DISPLACEMENT_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 30; }
-	override string GetDescription() { return "Partly severs your link to this world and gives you the ability to fly for 4 seconds, then teleports you to where you cast the spell. Enemies cannot see you while being displaced."; }
-	override string GetTechnicalInfo() { return "Self"; }
+	override string GetDescription() { return loc("$ALTERATION_DISPLACEMENT_DESC"); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_DISPLACEMENT_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'DisplacementSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Alteration/FarReach.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/FarReach.zsc
@@ -2,11 +2,11 @@ class FarReachSpell : ArcanumSpell
 {
 	override int GetIndex() { return 0; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Far Reach"; }
+	override string GetName() { return loc("$ALTERATION_FARREACH_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 10; }
-	override string GetDescription() { return String.Format("Open doors, trigger switches, and pick up items within a range of \c[Gold]%.1f\c-m.\nDisarms ammo boxes.\n\n\c[Fire]You can launch yourself forward with this spell. Use with caution.\c-", 20 + 40 * GetExperienceFactor()); }
-	override string GetTechnicalInfo() { return "Targeted"; }
+	override string GetDescription() { return String.Format(loc("$ALTERATION_FARREACH_DESCRIPTION"), 20 + 40 * GetExperienceFactor()); }
+	override string GetTechnicalInfo() { return loc("ALTERATION_FARREACH_INFO"); }
 	override int GetMaxExperience() { return 250; }
 	override class<ArcanumSigil> GetSigil() { return 'FarReachSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Alteration/Feather.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/Feather.zsc
@@ -2,11 +2,11 @@ class FeatherSpell : ArcanumSpell
 {
 	override int GetIndex() { return 50; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Feather"; }
+	override string GetName() { return loc("$ALTERATION_FEATHER_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 20; }
-	override string GetDescription() { return String.Format("Creates a circle at target location. Players falling into the circle get their vertical velocity reduced to a safe level. Gravity is also reduced."); }
-	override string GetTechnicalInfo() { return "Targeted"; }
+	override string GetDescription() { return String.Format(loc("$ALTERATION_FEATHER_DESC")); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_FEATHER_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'FeatherSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Alteration/Haste.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/Haste.zsc
@@ -2,11 +2,11 @@ class HasteSpell : ArcanumSpell
 {
 	override int GetIndex() { return 30; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Haste"; }
+	override string GetName() { return loc("$ALTERATION_HASTE_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 100; }
-	override string GetDescription() { return String.Format("All visible players within 20m get an increase to speed by \c[Gold]%i\c-%%. Effect expires after \c[Gold]%.1f\c- km.", 75 + int(50 * GetExperienceFactor()), (2500 + 7500 * GetExperienceFactor()) / 1000.0); }
-	override string GetTechnicalInfo() { return "Mass"; }
+	override string GetDescription() { return String.Format(loc("$ALTERATION_HASTE_DESC"), 75 + int(50 * GetExperienceFactor()), (2500 + 7500 * GetExperienceFactor()) / 1000.0); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_HASTE_INFO"); }
 	override int GetMaxExperience() { return 100; }
 	override class<ArcanumSigil> GetSigil() { return 'HasteSigil'; }
 	override void DrawHudStuff(HDStatusBar sb, HDPlayerPawn hpl, HDArcanumTome tome)

--- a/zscript/accensus/arcanum/Spells/Alteration/HoradricMalus.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/HoradricMalus.zsc
@@ -2,11 +2,11 @@ class HoradricMalusSpell : ArcanumSpell
 {
 	override int GetIndex() { return 40; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Horadric Malus"; }
+	override string GetName() { return loc("$ALTERATION_HORADRICMALUS_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 60; }
-	override string GetDescription() { return String.Format("Repairs repairable items by \c[Gold]%i%%\c- of their missing durability. Repairs Vulcanettes and *.E.R.P.s, among other things.", int(35 + 45 * GetExperienceFactor())); }
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetDescription() { return String.Format(loc("$ALTERATION_HORADRICMALUS_DESC"), int(35 + 45 * GetExperienceFactor())); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_HORADRICMALUS_INFO"); }
 	override int GetMaxExperience() { return 100; }
 	override class<ArcanumSigil> GetSigil() { return 'HoradricMalusSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Alteration/MassRecall.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/MassRecall.zsc
@@ -2,11 +2,11 @@ class MassRecallSpell : ArcanumSpell
 {
 	override int GetIndex() { return 90; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Mass Recall"; }
+	override string GetName() { return loc("$ALTERATION_MASSRECALL_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 50; }
-	override string GetDescription() { return "Teleports all players, dead or alive, to the circle."; }
-	override string GetTechnicalInfo() { return "Mass"; }
+	override string GetDescription() { return loc("$ALTERATION_MASSRECALL_DESC"); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_MASSRECALL_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'MassRecallSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Alteration/Reenergize.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/Reenergize.zsc
@@ -2,11 +2,11 @@ class ReenergizeSpell : ArcanumSpell
 {
 	override int GetIndex() { return 60; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Reenergize"; }
+	override string GetName() { return loc("$ALTERATION_REENERGIZE_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 30; }
-	override string GetDescription() { return String.Format("Restores up to \c[Gold]%i\c- battery charge, filling partial batteries first.", int(20 + 80 * GetExperienceFactor())); }
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetDescription() { return String.Format(loc("$ALTERATION_REENERGIZE_DESC"), int(20 + 80 * GetExperienceFactor())); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_REENERGIZE_INFO"); }
 	override int GetMaxExperience() { return 200; }
 	override class<ArcanumSigil> GetSigil() { return 'ReenergizeSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Alteration/Shield.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/Shield.zsc
@@ -2,11 +2,11 @@ class ShieldSpell : ArcanumSpell
 {
 	override int GetIndex() { return 20; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Shield"; }
+	override string GetName() { return loc("$ALTERATION_SHIELD_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 70; }
-	override string GetDescription() { return String.Format("Target is surrounded with a shield that can absorb up to \c[Gold]%i\c- damage. Shield helps put out fire.", int(2000 + 8000 * GetExperienceFactor())); }
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetDescription() { return String.Format(loc("$ALTERATION_SHIELD_DESC"), int(2000 + 8000 * GetExperienceFactor())); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_SHIELD_INFO"); }
 	override int GetMaxExperience() { return 110; }
 	override class<ArcanumSigil> GetSigil() { return 'ShieldSigil'; }
 	override void DrawHudStuff(HDStatusBar sb, HDPlayerPawn hpl, HDArcanumTome tome)

--- a/zscript/accensus/arcanum/Spells/Alteration/Worldbreaker.zsc
+++ b/zscript/accensus/arcanum/Spells/Alteration/Worldbreaker.zsc
@@ -2,11 +2,11 @@ class WorldbreakerSpell : ArcanumSpell
 {
 	override int GetIndex() { return 10; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeAlteration'; }
-	override string GetName() { return "Worldbreaker"; }
+	override string GetName() { return loc("$ALTERATION_WORLDBREAKER_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 60; }
-	override string GetDescription() { return String.Format("Destroys the target geometry. Maximum sector dimensions: \c[Gold]%ix%i\c-\n\n\c[Fire]Effect occurs 3 seconds after activation.\c-", int(128 + 256 * GetExperienceFactor()), int(32 + 64 * GetExperienceFactor())); }
-	override string GetTechnicalInfo() { return "Targeted, Touch"; }
+	override string GetDescription() { return String.Format(loc("$ALTERATION_WORLDBREAKER_DESC"), int(128 + 256 * GetExperienceFactor()), int(32 + 64 * GetExperienceFactor())); }
+	override string GetTechnicalInfo() { return loc("$ALTERATION_WORLDBREAKER_INFO"); }
 	override int GetMaxExperience() { return 60; }
 	override class<ArcanumSigil> GetSigil() { return 'WorldbreakerSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Conjuration/Barrier.zsc
+++ b/zscript/accensus/arcanum/Spells/Conjuration/Barrier.zsc
@@ -2,11 +2,11 @@ class BarrierSpell : ArcanumSpell
 {
 	override int GetIndex() { return 20; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeConjuration'; }
-	override string GetName() { return "Barrier"; }
+	override string GetName() { return loc("$CONJURATION_BARRIER_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 35; }
-	override string GetDescription() { return "Creates a 10m-wide impenetrable energy wall 1m in front of you. Lasts 90 seconds. Blocks movement and projectiles."; }
-	override string GetTechnicalInfo() { return "Touch"; }
+	override string GetDescription() { return loc("$CONJURATION_BARRIER_DESC"); }
+	override string GetTechnicalInfo() { return loc("$CONJURATION_BARRIER_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'BarrierSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Conjuration/Bridge.zsc
+++ b/zscript/accensus/arcanum/Spells/Conjuration/Bridge.zsc
@@ -2,11 +2,11 @@ class BridgeSpell : ArcanumSpell
 {
 	override int GetIndex() { return 30; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeConjuration'; }
-	override string GetName() { return "Bridge"; }
+	override string GetName() { return loc("$CONJURATION_BRIDGE_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 35; }
-	override string GetDescription() { return "Creates a 20m-long energy bridge. Lasts 30 seconds."; }
-	override string GetTechnicalInfo() { return "Angled"; }
+	override string GetDescription() { return loc("$CONJURATION_BRIDGE_DESC"); }
+	override string GetTechnicalInfo() { return loc("$CONJURATION_BRIDGE_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'BridgeSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Conjuration/Candlelight.zsc
+++ b/zscript/accensus/arcanum/Spells/Conjuration/Candlelight.zsc
@@ -2,11 +2,11 @@ class CandlelightSpell : ArcanumSpell
 {
 	override int GetIndex() { return 40; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeConjuration'; }
-	override string GetName() { return "Candlelight"; }
+	override string GetName() { return loc("$CONJURATION_CANDLELIGHT_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 5; }
-	override string GetDescription() { return String.Format("Emit a bright light with a radius of \c[Gold]%.1f\c-m for \c[Gold]%.1f\c- minutes.", 5 + 5 * GetExperienceFactor(), 5 + 5 * GetExperienceFactor()); }
-	override string GetTechnicalInfo() { return "Self"; }
+	override string GetDescription() { return String.Format(loc("$CONJURATION_CANDLELIGHT_DESC"), 5 + 5 * GetExperienceFactor(), 5 + 5 * GetExperienceFactor()); }
+	override string GetTechnicalInfo() { return loc("$CONJURATION_CANDLELIGHT_INFO"); }
 	override int GetMaxExperience() { return 100; }
 	override class<ArcanumSigil> GetSigil() { return 'CandlelightSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Conjuration/GhostSquad.zsc
+++ b/zscript/accensus/arcanum/Spells/Conjuration/GhostSquad.zsc
@@ -8,9 +8,9 @@ class GhostSquadSpell : ArcanumSpell
 	override string GetDescription()
 	{
 		int count = int(1 + 2 * GetExperienceFactor());
-		return String.Format("Summons \c[Gold]%i\c- ghost marine%s at target location.", count, count > 1 ? "s" : "");
+		return String.Format(loc("$CONJURATION_GHOSTSQUAD_DESC"), count, count > 1 ? loc("$CONJURATION_GHOSTSQUAD_DESC2") : "");
 	}
-	override string GetTechnicalInfo() { return "Targeted"; }
+	override string GetTechnicalInfo() { return loc("$CONJURATION_GHOSTSQUAD_INFO"); }
 	override int GetMaxExperience() { return 60; }
 	override class<ArcanumSigil> GetSigil() { return 'GhostSquadSigil'; }
 }
@@ -40,10 +40,10 @@ class GhostSquadSigil : ArcanumSigil
 			string deadawaken;
 			switch (random(0, 3))
 			{
-				case 0: deadawaken = "\cj'They shall stand again and hear there\n\cja horn in the hills ringing.\n\n\cjWhose shall the horn be?'"; break;
-				case 1: deadawaken = "\cj'For this war will last through years uncounted\n\n\cjand you shall be summoned once again ere the end.'"; break;
-				case 2: deadawaken = "\cj'Faint cries I heard,and dim horns blowing,\n\n\cjand a murmur as of countless far voices:\n\n\n\cjit was like the echo of some forgotten battle\n\n\cjin the Dark Years long ago.'"; break;
-				case 3: deadawaken = "\cj'Pale swords were drawn; but I know not\n\n\cjwhether their blades would still bite,\n\n\n\cjfor the Dead needed no longer\n\n\cjany weapon but fear.'"; break;
+				case 0: deadawaken = Stringtable.Localize("$CONJURATION_GHOSTSQUAD_ACTIVATE1"); break;
+				case 1: deadawaken = Stringtable.Localize("$CONJURATION_GHOSTSQUAD_ACTIVATE2"); break;
+				case 2: deadawaken = Stringtable.Localize("$CONJURATION_GHOSTSQUAD_ACTIVATE3"); break;
+				case 3: deadawaken = Stringtable.Localize("$CONJURATION_GHOSTSQUAD_ACTIVATE4"); break;
 			}
 			A_PrintBold(deadawaken, deadawaken.length() * 0.05, "NewSmallFont");
 			master.SetXYZ(OldPos);

--- a/zscript/accensus/arcanum/Spells/Conjuration/GuardianOrb.zsc
+++ b/zscript/accensus/arcanum/Spells/Conjuration/GuardianOrb.zsc
@@ -2,15 +2,15 @@ class GuardianOrbSpell : ArcanumSpell
 {
 	override int GetIndex() { return 0; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeConjuration'; }
-	override string GetName() { return "Guardian Orb"; }
+	override string GetName() { return loc("$CONJURATION_GUARDIANORB_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 60; }
 	override string GetDescription()
 	{
 		int count = int(1 + 2 * GetExperienceFactor());
-		return String.Format("A point defense orb that orbits its target, shooting down inbound tracers and small floating monsters within 5m. Can summon up to \c[Gold]%i\c- orb%s.", count, count > 1 ? "s" : "");
+		return String.Format(loc("$CONJURATION_GUARDIANORB_DESC"), count, count > 1 ? loc("$CONJURATION_GUARDIANORB_DESC2") : "");
 	}
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetTechnicalInfo() { return loc("$CONJURATION_GUARDIANORB_INFO"); }
 	override int GetMaxExperience() { return 80; }
 	override class<ArcanumSigil> GetSigil() { return 'GuardianOrbSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Conjuration/HolyForce.zsc
+++ b/zscript/accensus/arcanum/Spells/Conjuration/HolyForce.zsc
@@ -2,11 +2,11 @@ class HolyForceSpell : ArcanumSpell
 {
 	override int GetIndex() { return 10; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeConjuration'; }
-	override string GetName() { return "Holy Force"; }
+	override string GetName() { return loc("$CONJURATION_HOLYFORCE_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 40; }
-	override string GetDescription() { return String.Format("Prevents all archviles within 20m from disappearing until they die. Forces it out of hiding if it's invisible. If no archviles were affected, trigger nearby curses, if any. Reveals possessed barrels."); }
-	override string GetTechnicalInfo() { return "Mass"; }
+	override string GetDescription() { return String.Format(loc("$CONJURATION_HOLYFORCE_DESC")); }
+	override string GetTechnicalInfo() { return loc("$CONJURATION_HOLYFORCE_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'HolyForceSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Destruction/Claymore.zsc
+++ b/zscript/accensus/arcanum/Spells/Destruction/Claymore.zsc
@@ -2,11 +2,11 @@ class ClaymoreSpell : ArcanumSpell
 {
 	override int GetIndex() { return 10; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeDestruction'; }
-	override string GetName() { return "Claymore"; }
+	override string GetName() { return loc("$DESTRUCTION_CLAYMORE_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 5; }
-	override string GetDescription() { return "Activate the rune to create a trap that will activate when an enemy is in front of it."; }
-	override string GetTechnicalInfo() { return "Touch, Physical"; }
+	override string GetDescription() { return loc("$DESTRUCTION_CLAYMORE_DESC"); }
+	override string GetTechnicalInfo() { return loc("$DESTRUCTION_CLAYMORE_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'ClaymoreSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Destruction/Fireball.zsc
+++ b/zscript/accensus/arcanum/Spells/Destruction/Fireball.zsc
@@ -2,11 +2,11 @@ class FireballSpell : ArcanumSpell
 {
 	override int GetIndex() { return 0; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeDestruction'; }
-	override string GetName() { return "Fireball"; }
+	override string GetName() { return loc("$DESTRUCTION_FIREBALL_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 2; }
-	override string GetDescription() { return String.Format("Barrage target area with \c[Gold]%i\c- fireballs.", int(5 + 45 * GetExperienceFactor())); }
-	override string GetTechnicalInfo() { return "Targeted, Thermal, Dangerous"; }
+	override string GetDescription() { return String.Format(loc("$DESTRUCTION_FIREBALL_DESC"), int(5 + 45 * GetExperienceFactor())); }
+	override string GetTechnicalInfo() { return loc("$DESTRUCTION_FIREBALL_INFO"); }
 	override int GetMaxExperience() { return 300; }
 	override class<ArcanumSigil> GetSigil() { return 'FireballSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Destruction/Hammerfist.zsc
+++ b/zscript/accensus/arcanum/Spells/Destruction/Hammerfist.zsc
@@ -2,11 +2,11 @@ class HammerfistSpell : ArcanumSpell
 {
 	override int GetIndex() { return 30; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeDestruction'; }
-	override string GetName() { return "Hammerfist"; }
+	override string GetName() { return loc("$DESTRUCTION_HAMMERFIST_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 60; }
-	override string GetDescription() { return String.Format("A giant fist drops down from the sky and crushes a single target."); }
-	override string GetTechnicalInfo() { return "Targeted, Physical"; }
+	override string GetDescription() { return String.Format(loc("$DESTRUCTION_HAMMERFIST_DESC")); }
+	override string GetTechnicalInfo() { return loc("$DESTRUCTION_HAMMERFIST_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'HammerfistSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Destruction/Immolation.zsc
+++ b/zscript/accensus/arcanum/Spells/Destruction/Immolation.zsc
@@ -2,11 +2,11 @@ class ImmolationSpell : ArcanumSpell
 {
 	override int GetIndex() { return 40; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeDestruction'; }
-	override string GetName() { return "Immolation"; }
+	override string GetName() { return loc("$DESTRUCTION_IMMOLATION_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 120; }
-	override string GetDescription() { return String.Format("Sets all enemies within \c[Gold]%.1f\c-m on fire.", 10 + 20 * GetExperienceFactor()); }
-	override string GetTechnicalInfo() { return "Mass, Thermal"; }
+	override string GetDescription() { return String.Format(loc("$DESTRUCTION_IMMOLATION_DESC"), 10 + 20 * GetExperienceFactor()); }
+	override string GetTechnicalInfo() { return loc("$DESTRUCTION_IMMOLATION_INFO"); }
 	override int GetMaxExperience() { return 40; }
 	override class<ArcanumSigil> GetSigil() { return 'ImmolationSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Destruction/Thunderclap.zsc
+++ b/zscript/accensus/arcanum/Spells/Destruction/Thunderclap.zsc
@@ -2,16 +2,16 @@ class ThunderclapSpell : ArcanumSpell
 {
 	override int GetIndex() { return 20; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeDestruction'; }
-	override string GetName() { return "Thunderclap"; }
+	override string GetName() { return loc("$DESTRUCTION_THUNDERCLAP_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 6; }
 	override string GetDescription()
 	{
 		int count = int(1 + 4 * GetExperienceFactor());
-		return String.Format("Strikes target area with \c[Gold]%i\c- lightning bolt%s.", count, count > 1 ? "s" : "");
+		return String.Format(loc("$DESTRUCTION_THUNDERCLAP_DESC"), count, count > 1 ? "s" : "");
 	}
 	override int GetMaxExperience() { return 300; }
-	override string GetTechnicalInfo() { return "Targeted, AoE, Electrical, Dangerous"; }
+	override string GetTechnicalInfo() { return loc("$DESTRUCTION_THUNDERCLAP_INFO"); }
 	override class<ArcanumSigil> GetSigil() { return 'ThunderclapSigil'; }
 }
 

--- a/zscript/accensus/arcanum/Spells/Destruction/Voidstorm.zsc
+++ b/zscript/accensus/arcanum/Spells/Destruction/Voidstorm.zsc
@@ -2,11 +2,11 @@ class VoidstormSpell : ArcanumSpell
 {
 	override int GetIndex() { return 50; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeDestruction'; }
-	override string GetName() { return "Voidstorm"; }
+	override string GetName() { return loc("$DESTRUCTION_VOIDSTORM_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 200; }
-	override string GetDescription() { return "Launches forward a black hole that sucks enemies in and removes them from existence. It explodes once it comes into contact with a hard surface."; }
-	override string GetTechnicalInfo() { return "Mass, Dangerous"; }
+	override string GetDescription() { return loc("$DESTRUCTION_VOIDSTORM_DESC"); }
+	override string GetTechnicalInfo() { return loc("$DESTRUCTION_VOIDSTORM_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'VoidstormSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Restoration/Invulnerability.zsc
+++ b/zscript/accensus/arcanum/Spells/Restoration/Invulnerability.zsc
@@ -2,11 +2,11 @@ class InvulnerabilitySpell : ArcanumSpell
 {
 	override int GetIndex() { return 60; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeRestoration'; }
-	override string GetName() { return "Invulnerability"; }
+	override string GetName() { return loc("$RESTORATION_INVULNERABILITY_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 200; }
-	override string GetDescription() { return "Grants temporary invulnerability that lasts 90 seconds.\n\n\c[Fire]Warning: will set everything on fire.\c-"; }
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetDescription() { return loc("$RESTORATION_INVULNERABILITY_DESC"); }
+	override string GetTechnicalInfo() { return loc("$RESTORATION_INVULNERABILITY_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'InvulnerabilitySigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Restoration/LifeForce.zsc
+++ b/zscript/accensus/arcanum/Spells/Restoration/LifeForce.zsc
@@ -2,15 +2,15 @@ class LifeForceSpell : ArcanumSpell
 {
 	override int GetIndex() { return 10; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeRestoration'; }
-	override string GetName() { return "Life Force"; }
+	override string GetName() { return loc("$RESTORATION_LIFEFORCE_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 25; }
 	override string GetDescription()
 	{
 		double fac = GetExperienceFactor();
-		return String.Format("Fixes all wounds and restores \c[Gold]%i\c-%% of missing health. Heals \c[Gold]%i\c- burns. Reduces aggro by \c[Gold]%i\c-. Restores lost blood and removes incap.", int(25 + 75 * fac), int(25 + 50 * fac), int(10 + 20 * fac));
+		return String.Format(loc("$RESTORATION_LIFEFORCE_DESC"), int(25 + 75 * fac), int(25 + 50 * fac), int(10 + 20 * fac));
 	}
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetTechnicalInfo() { return loc("$RESTORATION_LIFEFORCE_INFO"); }
 	override int GetMaxExperience() { return 100; }
 	override class<ArcanumSigil> GetSigil() { return 'LifeForceSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Restoration/Rage.zsc
+++ b/zscript/accensus/arcanum/Spells/Restoration/Rage.zsc
@@ -2,11 +2,11 @@ class RageSpell : ArcanumSpell
 {
 	override int GetIndex() { return 11; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeRestoration'; }
-	override string GetName() { return "Rage"; }
+	override string GetName() { return loc("$RESTORATION_RAGE_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 90; }
-	override string GetDescription() { return String.Format("[this page is full of incomprehensible scribbles]"); }
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetDescription() { return String.Format(loc("$RESTORATION_RAGE_DESC")); }
+	override string GetTechnicalInfo() { return loc("$RESTORATION_RAGE_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'RageSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Restoration/Resurrect.zsc
+++ b/zscript/accensus/arcanum/Spells/Restoration/Resurrect.zsc
@@ -2,11 +2,11 @@ class ResurrectSpell : ArcanumSpell
 {
 	override int GetIndex() { return 30; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeRestoration'; }
-	override string GetName() { return "Resurrect"; }
+	override string GetName() { return loc("$RESTORATION_RESURRECT_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass; }
 	override int GetManaCost() { return 100; }
-	override string GetDescription() { return String.Format("Resurrects up to \c[Gold]%i\c- targets within \c[Gold]%.1f\c-m of where the sigil was cast.", int(10 + 40 * GetExperienceFactor()), 5 + 25 * GetExperienceFactor()); }
-	override string GetTechnicalInfo() { return "Mass"; }
+	override string GetDescription() { return String.Format(loc("$RESTORATION_RESURRECT_DESC"), int(10 + 40 * GetExperienceFactor()), 5 + 25 * GetExperienceFactor()); }
+	override string GetTechnicalInfo() { return loc("$RESTORATION_RESURRECT_INFO"); }
 	override int GetMaxExperience() { return 80; }
 	override class<ArcanumSigil> GetSigil() { return 'ResurrectSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Restoration/Revitalization.zsc
+++ b/zscript/accensus/arcanum/Spells/Restoration/Revitalization.zsc
@@ -2,11 +2,11 @@ class RevitalizationSpell : ArcanumSpell
 {
 	override int GetIndex() { return 0; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeRestoration'; }
-	override string GetName() { return "Revitalization"; }
+	override string GetName() { return loc("$RESTORATION_REVITALIZATION_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 30; }
-	override string GetDescription() { return String.Format("Recover \c[Gold]%i\c- health every heartbeat. Effect expires after \c[Gold]%i\c- health points. Prevents pain jolts from second flesh for the duration of the effect. Helps with zerk comedown.", int(1 + 2 * GetExperienceFactor()), int(200 + 800 * GetExperienceFactor())); }
-	override string GetTechnicalInfo() { return "Self, Targeted, Touch"; }
+	override string GetDescription() { return String.Format(loc("$RESTORATION_REVITALIZATION_DESC"), int(1 + 2 * GetExperienceFactor()), int(200 + 800 * GetExperienceFactor())); }
+	override string GetTechnicalInfo() { return loc("$RESTORATION_REVITALIZATION_INFO"); }
 	override int GetMaxExperience() { return 160; }
 	override class<ArcanumSigil> GetSigil() { return 'RevitalizationSigil'; }
 	override void DrawHudStuff(HDStatusBar sb, HDPlayerPawn hpl, HDArcanumTome tome)

--- a/zscript/accensus/arcanum/Spells/Restoration/SoulGuard.zsc
+++ b/zscript/accensus/arcanum/Spells/Restoration/SoulGuard.zsc
@@ -2,15 +2,15 @@ class SoulGuardSpell : ArcanumSpell
 {
 	override int GetIndex() { return 40; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeRestoration'; }
-	override string GetName() { return "Shield Guard"; }
+	override string GetName() { return loc("$RESTORATION_SOULGUARD_NAME"); }
 	override int GetSpellType() { return SType_SelfOrMass | SType_Targeted; }
 	override int GetManaCost() { return 75; }
 	override string GetDescription()
 	{
 		int layers = int(1 + 2 * GetExperienceFactor());
-		return String.Format("Creates a shieldcore.", layers, layers > 1 ? "s" : "");
+		return String.Format(loc("$RESTORATION_SOULGUARD_DESC"), layers, layers > 1 ? loc("$RESTORATION_SOULGUARD_DESC2") : "");
 	}
-	override string GetTechnicalInfo() { return "Self, Targeted"; }
+	override string GetTechnicalInfo() { return loc("$RESTORATION_SOULGUARD_INFO"); }
 	override int GetMaxExperience() { return 40; }
 	override class<ArcanumSigil> GetSigil() { return 'SoulGuardSigil'; }
 }

--- a/zscript/accensus/arcanum/Spells/Restoration/Transfusion.zsc
+++ b/zscript/accensus/arcanum/Spells/Restoration/Transfusion.zsc
@@ -2,11 +2,11 @@ class TransfusionSpell : ArcanumSpell
 {
 	override int GetIndex() { return 20; }
 	override class<ArcanumSpellTree> GetTree() { return 'ArcanumTreeRestoration'; }
-	override string GetName() { return "Transfusion"; }
+	override string GetName() { return loc("$RESTORATION_TRANSFUSION_NAME"); }
 	override int GetSpellType() { return SType_Targeted; }
 	override int GetManaCost() { return 10; }
-	override string GetDescription() { return String.Format("Transfers all of the tome's stored blues to the target."); }
-	override string GetTechnicalInfo() { return "Targeted, Touch"; }
+	override string GetDescription() { return String.Format(loc("$RESTORATION_TRANSFUSION_DESC")); }
+	override string GetTechnicalInfo() { return loc("$RESTORATION_TRANSFUSION_INFO"); }
 	override int GetMaxExperience() { return 0; }
 	override class<ArcanumSigil> GetSigil() { return 'TransfusionSigil'; }
 }


### PR DESCRIPTION
Localizes the book itself, the weapon helptext, all of the spells and spell trees and mana barrels, along with fixing the Shield Guard description to be more like the original Soul Guard description.